### PR TITLE
docs: use pnpm run plugins install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Based on https://github.com/cgiffard/TextStatistics.js
 
 ## Installation
-Install using /admin/plugins or npm install ep_text_statistics
+Install using /admin/plugins or pnpm run plugins install ep_text_statistics
 
 ## Usage
 When you type a button in the editbar will show the reading ease of the pad


### PR DESCRIPTION
## Summary
Etherpad uses pnpm internally. The canonical install command per [etherpad-lite/doc/plugins.md](https://github.com/ether/etherpad-lite/blob/develop/doc/plugins.md) is `pnpm run plugins install ep_<name>`, not `npm install`. Update README to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)